### PR TITLE
Update requirements.txt

### DIFF
--- a/simulator2d/requirements.txt
+++ b/simulator2d/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.16.2
 opencv-python==4.0.0.21
 PyYAML==5.1
+pillow==6.2.1


### PR DESCRIPTION
Need to install pillow here.
Without this line, I experienced following error.

```
~/dev/chainer-ev3/simulator2d master
❯ pip install -r requirements.txt 
Collecting numpy==1.16.2 (from -r requirements.txt (line 1))
  Downloading https://files.pythonhosted.org/packages/93/0e/30aaa357c3065957344b24048281
8eef31d4080f73dfa5f1ef7dcd8744d2/numpy-1.16.2-cp36-cp36m-macosx_10_6_intel.macosx_10_9_i
ntel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl (13.9MB)
    100% |████████████████████████████████| 13.9MB 1.1MB/s 
Collecting opencv-python==4.0.0.21 (from -r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/52/96/2fcb50d675928643edd9cc4ed39c
df92985abb742263980ee2cdd611cb24/opencv_python-4.0.0.21-cp36-cp36m-macosx_10_6_x86_64.ma
cosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl (39.7MB)
    100% |████████████████████████████████| 39.7MB 645kB/s 
Collecting PyYAML==5.1 (from -r requirements.txt (line 3))
  Downloading https://files.pythonhosted.org/packages/9f/2c/9417b5c774792634834e73093274
5bc09a7d36754ca00acf1ccd1ac2594d/PyYAML-5.1.tar.gz (274kB)                             
    100% |████████████████████████████████| 276kB 1.7MB/s                               
Installing collected packages: numpy, opencv-python, PyYAML                             
  Running setup.py install for PyYAML ... done
Successfully installed PyYAML-5.1 numpy-1.16.2 opencv-python-4.0.0.21                   
You are using pip version 18.1, however version 19.3.1 is available.              
You should consider upgrading via the 'pip install --upgrade pip' command.
                                                                                        
~/dev/chainer-ev3/simulator2d master 40s                                                
❯ python main.py                                                                        
Traceback (most recent call last):   
  File "main.py", line 13, in <module>
    from env import EV3Env                                                              
  File "/Users/kumezawa/dev/chainer-ev3/simulator2d/env.py", line 6, in <module>
    from PIL import Image
ModuleNotFoundError: No module named 'PIL'
```